### PR TITLE
Password creds

### DIFF
--- a/src/pykeycloak/client.py
+++ b/src/pykeycloak/client.py
@@ -56,6 +56,14 @@ class Client(object):
         self._access_token = res['access_token']
         self._refresh_token = res['refresh_token']
 
+    def password_credentials(self, username: str, password: str):
+        '''
+            create new tokens using username and password
+        '''
+        res = self._client.password_credentials(username, password)
+        self._access_token = res['access_token']
+        self._refresh_token = res['refresh_token']
+
     def token_exchange(self, audience):
         '''
             return a new token for audience (local client within the same realm) based on 

--- a/src/pykeycloak/client.py
+++ b/src/pykeycloak/client.py
@@ -1,4 +1,3 @@
-from urllib import HTTPError
 from keycloak.realm import KeycloakRealm
 
 class Client(object):


### PR DESCRIPTION
Added a means to provide username and password to get initial access and refresh tokens.
This is an alternative to giving the initial tokens in the config.